### PR TITLE
feat: add workload identity and AGIC configuration

### DIFF
--- a/deployment/main.bicep
+++ b/deployment/main.bicep
@@ -22,6 +22,9 @@ param storageAccountName string = 'resp${uniqueString(resourceGroup().id)}store'
 @description('The SKU for the Azure Storage Account.')
 param storageAccountSku string = 'Standard_LRS'
 
+@description('Name of the user-assigned managed identity used by pods via workload identity')
+param podIdentityName string = '${resourcePrefix}-pod-identity'
+
 resource aksCluster 'Microsoft.ContainerService/managedClusters@2023-08-01' = {
   name: aksClusterName
   location: location
@@ -119,9 +122,18 @@ resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@20
   }
 }
 
+// User-assigned managed identity for Kubernetes workload identity
+resource podIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: podIdentityName
+  location: location
+}
+
 // Outputs for resource names and endpoints
 output aksClusterName string = aksCluster.name
 output acrName string = acr.name
 output openAiAccountName string = openAiAccount.name
 output storageAccountName string = storageAccount.name
 output storageAccountBlobEndpoint string = storageAccount.properties.primaryEndpoints.blob
+output podIdentityName string = podIdentity.name
+output podIdentityClientId string = podIdentity.properties.clientId
+output podIdentityResourceId string = podIdentity.id

--- a/deployment/respondr-k8s-template.yaml
+++ b/deployment/respondr-k8s-template.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: respondr
     spec:
+      serviceAccountName: respondr-sa
       containers:
       - name: respondr
         image: {{ACR_IMAGE_PLACEHOLDER}}
@@ -63,6 +64,14 @@ spec:
 
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: respondr-sa
+  annotations:
+    azure.workload.identity/client-id: CLIENT_ID_PLACEHOLDER
+
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: respondr-service
@@ -83,12 +92,12 @@ kind: Ingress
 metadata:
   name: respondr-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/auth-url: https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/authorize
+    appgw.ingress.kubernetes.io/auth-redirect: https://respondr.example.com
 spec:
-  ingressClassName: nginx
   rules:
-  - host: respondr.local
+  - host: respondr.example.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Summary
- create user-assigned managed identity for workloads and output identity details from bicep
- adjust Kubernetes manifests for Application Gateway Ingress Controller with Entra auth and workload identity service account
- enhance post-deploy script to configure workload identity, enable AGIC with Microsoft Entra authentication, and validate ingress/DNS

## Testing
- `pwsh ./run-tests.ps1`
- `pwsh deployment/post-deploy.ps1 -ResourceGroupName dummy -Location westus` *(fails: Missing aksClusterName output)*

------
https://chatgpt.com/codex/tasks/task_e_68914b074af083308bc1f1c0976cc7f2