### PR TITLE
Improve OAuth2 sign-in/out handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 from datetime import datetime, timedelta
+from urllib.parse import quote
 
 # Import fcntl only on Unix-like systems
 try:
@@ -472,7 +473,8 @@ def get_user_info(request: Request):
         "email": email,
         "name": display_name,
         "groups": [group.strip() for group in user_groups if group.strip()],
-        "logout_url": "/oauth2/sign_out"  # OAuth2 Proxy logout endpoint
+        # Redirect to root after logout so OAuth2 Proxy can initiate a new login
+        "logout_url": f"/oauth2/sign_out?rd={quote('/', safe='')}",
     })
 
 @app.get("/debug/pod-info")

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -187,7 +187,7 @@ def test_user_info():
     assert data["email"] == "test@example.com"
     assert data["name"] == "Test User"
     assert data["groups"] == ["group1", "group2", "group3"]
-    assert data["logout_url"] == "/oauth2/sign_out"
+    assert data["logout_url"] == "/oauth2/sign_out?rd=%2F"
 
 def test_user_info_minimal_headers():
     """Test the /api/user endpoint with minimal OAuth2 headers"""
@@ -203,7 +203,7 @@ def test_user_info_minimal_headers():
     assert data["email"] == "minimal@example.com"
     assert data["name"] == "minimal@example.com"  # Should fallback to email
     assert data["groups"] == []
-    assert data["logout_url"] == "/oauth2/sign_out"
+    assert data["logout_url"] == "/oauth2/sign_out?rd=%2F"
 
 def test_user_info_no_headers():
     """Test the /api/user endpoint with no OAuth2 headers"""
@@ -215,7 +215,7 @@ def test_user_info_no_headers():
     assert data["email"] is None
     assert data["name"] is None
     assert data["groups"] == []
-    assert data["logout_url"] == "/oauth2/sign_out"
+    assert data["logout_url"] == "/oauth2/sign_out?rd=%2F"
 
 def test_user_info_oauth2_proxy_headers():
     """Test the /api/user endpoint with OAuth2 Proxy standard headers"""
@@ -234,4 +234,4 @@ def test_user_info_oauth2_proxy_headers():
     assert data["email"] == "oauth2@example.com"
     assert data["name"] == "OAuth2 User"
     assert data["groups"] == ["admin", "users", "testers"]
-    assert data["logout_url"] == "/oauth2/sign_out"
+    assert data["logout_url"] == "/oauth2/sign_out?rd=%2F"

--- a/frontend/src/UserInfo.js
+++ b/frontend/src/UserInfo.js
@@ -4,6 +4,7 @@ import './UserInfo.css';
 function UserInfo() {
   const [user, setUser] = useState(null);
   const [error, setError] = useState(null);
+  const [logoutUrl, setLogoutUrl] = useState('/oauth2/sign_out?rd=/');
 
   useEffect(() => {
     const fetchUserInfo = async () => {
@@ -12,6 +13,9 @@ function UserInfo() {
         if (response.ok) {
           const userData = await response.json();
           setUser(userData);
+          if (userData.logout_url) {
+            setLogoutUrl(userData.logout_url);
+          }
         } else {
           setError('Failed to fetch user information');
         }
@@ -25,14 +29,24 @@ function UserInfo() {
   }, []);
 
   const handleLogout = () => {
-    // Redirect to OAuth2 Proxy logout endpoint
-    window.location.href = '/oauth2/sign_out';
+    window.location.href = logoutUrl;
+  };
+
+  const handleLogin = () => {
+    window.location.href = '/oauth2/start?rd=' + encodeURIComponent(window.location.pathname);
   };
 
   if (error) {
     return (
       <div className="user-info error">
         <span>⚠️ {error}</span>
+        <button
+          className="logout-button"
+          onClick={handleLogin}
+          title="Sign in"
+        >
+          🔐 Sign In
+        </button>
       </div>
     );
   }
@@ -45,14 +59,13 @@ function UserInfo() {
     );
   }
 
-  // Handle case where user is not properly authenticated
   if (!user.authenticated || (!user.name && !user.email)) {
     return (
       <div className="user-info error">
         <span>⚠️ Not authenticated</span>
-        <button 
-          className="logout-button" 
-          onClick={handleLogout}
+        <button
+          className="logout-button"
+          onClick={handleLogin}
           title="Sign in"
         >
           🔐 Sign In
@@ -69,8 +82,8 @@ function UserInfo() {
           <span className="user-email">({user.email})</span>
         )}
       </div>
-      <button 
-        className="logout-button" 
+      <button
+        className="logout-button"
         onClick={handleLogout}
         title="Sign out"
       >


### PR DESCRIPTION
## Summary
- Redirect logout endpoint back to the app so OAuth2 Proxy restarts auth
- Teach React UserInfo component to use backend logout URL and add explicit login flow
- Adjust tests for new logout redirect

## Testing
- `pytest backend/test_main.py`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68938440ca3483308364650a1f979f4d