### PR TITLE
Improve ETA duration handling

### DIFF
--- a/test_eta_conversion.py
+++ b/test_eta_conversion.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from datetime import datetime
+
+# Add backend to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'backend'))
+
+from main import convert_eta_to_timestamp
+
+
+def test_convert_eta_duration_variants():
+    base = datetime(2024, 1, 1, 12, 0)
+    assert convert_eta_to_timestamp("30m", base) == "12:30"
+    assert convert_eta_to_timestamp("2h", base) == "14:00"
+    assert convert_eta_to_timestamp("1.5 hours", base) == "13:30"
+    assert convert_eta_to_timestamp("in 45", base) == "12:45"
+    assert convert_eta_to_timestamp("~10 mins", base) == "12:10"


### PR DESCRIPTION
## Summary
- compute durations from model output in Azure OpenAI path
- expand `convert_eta_to_timestamp` to support decimal-hour and compact duration formats
- add regression tests for duration variants

## Testing
- `pytest -q` *(fails: SystemExit: 1 in backend/test_system.py)*
- `pytest -q test_eta_conversion.py test_soft_delete.py`


------
https://chatgpt.com/codex/tasks/task_e_6899771b6c548330aedec53c1ed8e724