### PR TITLE
Revert unintended dark mode changes on main page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,4 +1,3 @@
-/* Default to dark theme variables */
 :root {
   --bg: #121212;
   --bg-elev: #1a1a1a;
@@ -13,23 +12,6 @@
   --yellow: #b28704;
   --gray: #616161;
   --red: #c62828;
-}
-
-/* Light theme overrides when body has class 'light' */
-body.light {
-  --bg: #ffffff;
-  --bg-elev: #f5f5f5;
-  --bg-elev-2: #eeeeee;
-  --text: #212121;
-  --muted: #555555;
-  --divider: rgba(0,0,0,0.12);
-  --accent: #fb8c00;
-  --border: #dddddd;
-  --hover: rgba(0,0,0,0.04);
-  --green: #388e3c;
-  --yellow: #fbc02d;
-  --gray: #757575;
-  --red: #d32f2f;
 }
 
 .App {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -93,22 +93,6 @@ function MainApp() {
     eta_timestamp: '', // datetime-local string
   });
 
-  // Dark mode preference stored in localStorage
-  const [darkMode, setDarkMode] = useState(() => {
-    try {
-      return window.localStorage.getItem('respondr_dark') !== '0';
-    } catch {
-      return true; // default to dark
-    }
-  });
-
-  useEffect(() => {
-    document.body.classList.toggle('light', !darkMode);
-    try {
-      window.localStorage.setItem('respondr_dark', darkMode ? '1' : '0');
-    } catch {}
-  }, [darkMode]);
-
   const fetchData = useCallback(async () => {
     try {
       // Don't fetch data if user just logged out
@@ -610,7 +594,6 @@ function MainApp() {
         <div className="controls">
           <label className="toggle"><input type="checkbox" checked={live} onChange={e=>setLive(e.target.checked)} /> Live</label>
           <label className="toggle"><input type="checkbox" checked={useUTC} onChange={e=>setUseUTC(e.target.checked)} /> UTC</label>
-          <label className="toggle"><input type="checkbox" checked={darkMode} onChange={e=>setDarkMode(e.target.checked)} /> Dark</label>
           <button className="btn" onClick={()=>fetchData()} title="Refresh now">Refresh</button>
           <button className="btn" onClick={exportCsv} title="Export CSV">Export</button>
           <a href="/deleted-dashboard" className="btn" target="_blank" rel="noopener noreferrer" title="View deleted messages">Deleted</a>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,9 +5,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: var(--bg);
-  color: var(--text);
-  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 code {


### PR DESCRIPTION
## Summary
- Restore original dark theme styling for main page
- Remove dark mode toggle logic from main page to keep existing appearance

## Testing
- `npm test -- --watchAll=false`
- `pytest` *(fails: SystemExit: 1)*

------
https://chatgpt.com/codex/tasks/task_e_689992ad983c83308fd08587de4d8fc1